### PR TITLE
Improve object buffer handling. Use ob_end_clean rather than ob_end_flush

### DIFF
--- a/class-frontend.php
+++ b/class-frontend.php
@@ -194,7 +194,11 @@ add_shortcode( 'cookie', 'eu_cookie_shortcode' );
 //add_filter( 'widget_text','ecl_erase', 11 ); 
 
 function ecl_buffer_start() { ob_start("ecl_callback"); } 
-function ecl_buffer_end() { ob_end_flush();	}
+function ecl_buffer_end() {
+	$contents = ob_get_contents();
+	ob_end_clean();
+	echo $contents;
+}
 function ecl_callback($buffer) { return ecl_erase($buffer); }
 
 add_action('wp_head', 'ecl_buffer_start'); 


### PR DESCRIPTION
I had my own object buffering that worked 'outside' this plug-in's, and which buffered the entire page template. I found that the ob_end_flush() broke that - if I understand correctly it is because it sends the buffer directly to the browser(?). Cleaning the buffer instead and just printing the contents fixed the issue.
